### PR TITLE
feat: make custom_mapping_files extendable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,13 @@ https://www.youtube.com/watch?v=TGc2OyFQqXs
 For a written walkthrough, including screenshots, and explanation on the keyboard and mouse usage read below.
 
 ### Page 1, setting program arguments
-Upon starting the application, you'll be presented with a terminal interface to select the input file, mapping file, output file paths and the conversion. You can also pick your preferred language and a file path to save your manual mappings to, for future use. Yellow highlights the active field. Green indicates a valid path. Orange means a given output path will wipe and overwrite an existing file in that location. Red means it's invalid, which disables you from continuing to the next page.
+Upon starting the application, you'll be presented with a terminal interface to select the input file, mapping file, output file paths and the conversion. You can also pick your preferred language and a file path to save your manual mappings to, for future use. 
+
+All files/paths must be .json files/paths. The "Choose Mapping File" and the "Save Custom Mapping To" must be .json files be created by or in the same structure as this program generates, otherwise deserialization will error. When entering existing custom mapping file into "Save Custom Mapping To" it will be extended if new mappings are performed. Enter "DESM" in the "Choose Mapping File" prompt if you wish to make use of their mappings.
+
+Yellow highlights the active field. Green indicates a valid path. Orange means a given output path will wipe and overwrite an existing file in that location. Red means it's invalid, which disables you from continuing to the next page.
 On the bottom you'll find a bar explaining the basic keys as well.
+
 
 ![credential-converter_P1.png](https://github.com/impierce/credential-converter/raw/main/.github/credential-converter_P1.png)
 

--- a/src/backend/headless_cli.rs
+++ b/src/backend/headless_cli.rs
@@ -102,6 +102,7 @@ pub fn load_files_apply_transformations(state: &mut AppState) {
     if state.mapping_path == "DESM" {
         apply_desm_mapping(state);
     } else {
+        // todo: remove unwrap
         let rdr = std::fs::File::open(&state.mapping_path).unwrap();
         let transformations: Vec<Transformation> = serde_json::from_reader(rdr).unwrap();
 

--- a/src/events/p2_p3_common.rs
+++ b/src/events/p2_p3_common.rs
@@ -1,8 +1,8 @@
 use crossterm::event::MouseEvent;
 use serde_json::Value;
+use std::io::Write;
 use std::path::Path;
 use std::{char, fs::File};
-use std::io::Write;
 
 use super::{is_mouse_over_area, p2_handler::clear_progress};
 use crate::backend::preload_p2::get_json;
@@ -419,14 +419,9 @@ pub fn create_output_files(state: &mut AppState) {
             transformations.extend(state.performed_mappings.iter().cloned());
 
             let mut file = File::create(&state.custom_mapping_path).unwrap();
-            file.write_all(
-                serde_json::to_string_pretty(&transformations)
-                    .unwrap()
-                    .as_bytes(),
-            )
-            .unwrap();
-        }
-        else {
+            file.write_all(serde_json::to_string_pretty(&transformations).unwrap().as_bytes())
+                .unwrap();
+        } else {
             let mut file = File::create(&state.custom_mapping_path).unwrap();
             file.write_all(
                 serde_json::to_string_pretty(&state.performed_mappings)

--- a/src/events/p2_p3_common.rs
+++ b/src/events/p2_p3_common.rs
@@ -1,9 +1,11 @@
 use crossterm::event::MouseEvent;
 use serde_json::Value;
-use std::char;
+use std::path::Path;
+use std::{char, fs::File};
 use std::io::Write;
 
 use super::{is_mouse_over_area, p2_handler::clear_progress};
+use crate::backend::preload_p2::get_json;
 use crate::{
     backend::{
         candidate_value::{set_candidate_output_value, set_output_pointer},
@@ -399,9 +401,9 @@ pub fn next_page(state: &mut AppState) {
     state.page.next();
 }
 
+/// It is recommended not to alter the custom mapping files manually, since this will likely result in an error.
 pub fn create_output_files(state: &mut AppState) {
     let output_format = state.mapping.output_format();
-    trace_dbg!(&output_format); // testing
     let json_value = state.repository.get_mut(&output_format).unwrap();
 
     // Create Output File
@@ -410,15 +412,29 @@ pub fn create_output_files(state: &mut AppState) {
     file.write_all(serde_json::to_string_pretty(&json_value).unwrap().as_bytes())
         .unwrap();
 
-    // Create Mapping File
+    // Create Mapping File if empty, otherwise append to it.
     if !state.custom_mapping_path.is_empty() {
-        let mut file = std::fs::File::create(&state.custom_mapping_path).unwrap();
-        file.write_all(
-            serde_json::to_string_pretty(&state.performed_mappings)
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
+        if Path::new(&state.custom_mapping_path).is_file() {
+            let mut transformations: Vec<Transformation> = get_json(&state.custom_mapping_path).unwrap();
+            transformations.extend(state.performed_mappings.iter().cloned());
+
+            let mut file = File::create(&state.custom_mapping_path).unwrap();
+            file.write_all(
+                serde_json::to_string_pretty(&transformations)
+                    .unwrap()
+                    .as_bytes(),
+            )
+            .unwrap();
+        }
+        else {
+            let mut file = File::create(&state.custom_mapping_path).unwrap();
+            file.write_all(
+                serde_json::to_string_pretty(&state.performed_mappings)
+                    .unwrap()
+                    .as_bytes(),
+            )
+            .unwrap();
+        }
     }
 }
 

--- a/src/render/p1.rs
+++ b/src/render/p1.rs
@@ -1,6 +1,6 @@
 use crate::{
     popups::{render_popup_exit_warning, render_popup_overwrite_warning},
-    state::{translate, AppState, P1Prompts}
+    state::{translate, AppState, P1Prompts},
 };
 use ratatui::{
     buffer::Buffer,

--- a/src/render/p1.rs
+++ b/src/render/p1.rs
@@ -1,6 +1,6 @@
 use crate::{
     popups::{render_popup_exit_warning, render_popup_overwrite_warning},
-    state::{translate, AppState, P1Prompts},
+    state::{translate, AppState, P1Prompts}
 };
 use ratatui::{
     buffer::Buffer,
@@ -83,7 +83,7 @@ pub fn render_description_input_p1(area: Rect, buf: &mut Buffer, state: &mut App
 
     // Checking paths for validity/overwriting.
     let path = Path::new(&state.input_path);
-    if !path.is_file() {
+    if !path.is_file() || !state.input_path.ends_with(".json") {
         Paragraph::new(state.input_path.as_str())
             .block(input_prompt)
             .fg(Color::Red)
@@ -96,7 +96,7 @@ pub fn render_description_input_p1(area: Rect, buf: &mut Buffer, state: &mut App
     }
 
     let path = Path::new(&state.output_path);
-    if state.output_path.is_empty() {
+    if state.output_path.is_empty() || !state.output_path.ends_with(".json") {
         Paragraph::new(state.output_path.as_str())
             .block(output_prompt)
             .fg(Color::Red)
@@ -114,7 +114,7 @@ pub fn render_description_input_p1(area: Rect, buf: &mut Buffer, state: &mut App
     }
 
     let path = Path::new(&state.mapping_path);
-    if !path.is_file() && state.mapping_path != "DESM" {
+    if (!path.is_file() || !state.mapping_path.ends_with(".json")) && state.mapping_path != "DESM" {
         // !path.exists() ||
         Paragraph::new(state.mapping_path.as_str())
             .block(mapping_file_prompt)
@@ -150,16 +150,15 @@ pub fn render_description_input_p1(area: Rect, buf: &mut Buffer, state: &mut App
         .render(tabs_center, buf);
 
     // Custom mapping prompt
-    let path = Path::new(&state.custom_mapping_path);
     if state.custom_mapping_path.is_empty() {
         Paragraph::new(state.custom_mapping_path.as_str())
             .block(custom_mapping_prompt)
             .fg(Color::White)
             .render(custom_mapping, buf);
-    } else if path.is_file() {
+    } else if !state.custom_mapping_path.ends_with(".json") {
         Paragraph::new(state.custom_mapping_path.as_str())
             .block(custom_mapping_prompt)
-            .fg(Color::Rgb(240, 160, 100))
+            .fg(Color::Red)
             .render(custom_mapping, buf);
     } else {
         Paragraph::new(state.custom_mapping_path.as_str())


### PR DESCRIPTION
# Description of change
Before, any custom mapping file would be overwritten with the new mappings.
Now, existing files are extended.
Update overwritten paths display.
Update valid paths display to check if file is a .json file.

## Links to any relevant issues
-

## How the change has been tested
I've ran code with our test files by going through the CLI myself

## Definition of Done checklist
Add an `x` to the boxes that are relevant to your changes.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes